### PR TITLE
validate no object datatypes

### DIFF
--- a/semantic_model_generator/sqlgen/generate_sql.py
+++ b/semantic_model_generator/sqlgen/generate_sql.py
@@ -10,6 +10,9 @@ from semantic_model_generator.protos.semantic_model_pb2 import (
     Table,
     TimeDimension,
 )
+from semantic_model_generator.snowflake_utils.snowflake_connector import (
+    OBJECT_DATATYPES,
+)
 
 _AGGREGATION_FUNCTIONS = [
     "sum",
@@ -79,6 +82,10 @@ def _create_select_statement(table: Table, limit: int) -> str:
                 raise ValueError(
                     f"Aggregations aren't allowed in columns yet. Please remove from {expr}."
                 )
+        if col.data_type.upper() in OBJECT_DATATYPES:
+            raise ValueError(
+                f"We do not support object datatypes in the semantic model. Col {col.name} has data type {col.data_type}. Please remove this column from your semantic model."
+            )
 
         return expr
 

--- a/semantic_model_generator/tests/validate_model_test.py
+++ b/semantic_model_generator/tests/validate_model_test.py
@@ -348,7 +348,7 @@ def test_invalid_yaml_missing_quote(
     with pytest.raises(ValueError) as exc_info:
         validate(temp_invalid_yaml_unmatched_quote_file, account_name)
 
-    expected_error_fragment = "Unable to execute query with your logical table against physical tables on Snowflake. Error = Invalid column name 'ZIP_CODE\"'. Mismatched quotes detected."
+    expected_error_fragment = "Unable to execute query with your base table against physical tables on Snowflake. Error = Invalid column name 'ZIP_CODE\"'. Mismatched quotes detected."
 
     assert expected_error_fragment in str(exc_info.value), "Unexpected error message"
 
@@ -369,6 +369,6 @@ def test_invalid_yaml_incorrect_datatype(
     with pytest.raises(ValueError) as exc_info:
         validate(temp_invalid_yaml_incorrect_dtype, account_name)
 
-    expected_error = "Unable to execute query with your logical table against physical tables on Snowflake. Error = We do not support object datatypes in the semantic model. Col ZIP_CODE has data type OBJECT. Please remove this column from your semantic model."
+    expected_error = "Unable to execute query with your base table against physical tables on Snowflake. Error = We do not support object datatypes in the semantic model. Col ZIP_CODE has data type OBJECT. Please remove this column from your semantic model."
 
     assert expected_error in str(exc_info.value), "Unexpected error message"

--- a/semantic_model_generator/tests/validate_model_test.py
+++ b/semantic_model_generator/tests/validate_model_test.py
@@ -348,7 +348,7 @@ def test_invalid_yaml_missing_quote(
     with pytest.raises(ValueError) as exc_info:
         validate(temp_invalid_yaml_unmatched_quote_file, account_name)
 
-    expected_error_fragment = "Unable to execute query with your base table against physical tables on Snowflake. Error = Invalid column name 'ZIP_CODE\"'. Mismatched quotes detected."
+    expected_error_fragment = "Unable to execute query with your logical table against base tables on Snowflake. Error = Invalid column name 'ZIP_CODE\"'. Mismatched quotes detected."
 
     assert expected_error_fragment in str(exc_info.value), "Unexpected error message"
 
@@ -369,6 +369,6 @@ def test_invalid_yaml_incorrect_datatype(
     with pytest.raises(ValueError) as exc_info:
         validate(temp_invalid_yaml_incorrect_dtype, account_name)
 
-    expected_error = "Unable to execute query with your base table against physical tables on Snowflake. Error = We do not support object datatypes in the semantic model. Col ZIP_CODE has data type OBJECT. Please remove this column from your semantic model."
+    expected_error = "Unable to execute query with your logical table against base tables on Snowflake. Error = We do not support object datatypes in the semantic model. Col ZIP_CODE has data type OBJECT. Please remove this column from your semantic model."
 
     assert expected_error in str(exc_info.value), "Unexpected error message"

--- a/semantic_model_generator/tests/validate_model_test.py
+++ b/semantic_model_generator/tests/validate_model_test.py
@@ -194,6 +194,34 @@ tables:
 """
 
 
+_INVALID_YAML_INCORRECT_DATA_TYPE = """name: my test semantic model
+tables:
+  - name: ALIAS
+    base_table:
+      database: AUTOSQL_DATASET_BIRD_V2
+      schema: ADDRESS
+      table: ALIAS
+    dimensions:
+      - name: ALIAS
+        synonyms:
+            - 'an alias for something'
+        expr: ALIAS
+        data_type: TEXT
+        sample_values:
+          - Holtsville
+          - Adjuntas
+          - Boqueron
+    measures:
+      - name: ZIP_CODE
+        synonyms:
+            - 'another synonym'
+        expr: ZIP_CODE
+        data_type: OBJECT
+        sample_values:
+          - '{1:2}'
+"""
+
+
 @pytest.fixture
 def temp_valid_yaml_file():
     """Create a temporary YAML file with the test data."""
@@ -226,6 +254,15 @@ def temp_invalid_yaml_unmatched_quote_file():
     """Create a temporary YAML file with the test data."""
     with tempfile.NamedTemporaryFile(mode="w", delete=True) as tmp:
         tmp.write(_INVALID_YAML_UNMATCHED_QUOTE)
+        tmp.flush()
+        yield tmp.name
+
+
+@pytest.fixture
+def temp_invalid_yaml_incorrect_dtype():
+    """Create a temporary YAML file with the test data."""
+    with tempfile.NamedTemporaryFile(mode="w", delete=True) as tmp:
+        tmp.write(_INVALID_YAML_INCORRECT_DATA_TYPE)
         tmp.flush()
         yield tmp.name
 
@@ -322,3 +359,16 @@ def test_invalid_yaml_missing_quote(
     assert (
         expected_log_call not in mock_logger.mock_calls
     ), "Unexpected log message found in logger calls"
+
+
+@mock.patch("semantic_model_generator.validate_model.logger")
+def test_invalid_yaml_incorrect_datatype(
+    mock_logger, temp_invalid_yaml_incorrect_dtype, mock_snowflake_connection
+):
+    account_name = "snowflake test"
+    with pytest.raises(ValueError) as exc_info:
+        validate(temp_invalid_yaml_incorrect_dtype, account_name)
+
+    expected_error = "Unable to execute query with your logical table against physical tables on Snowflake. Error = We do not support object datatypes in the semantic model. Col ZIP_CODE has data type OBJECT. Please remove this column from your semantic model."
+
+    assert expected_error in str(exc_info.value), "Unexpected error message"

--- a/semantic_model_generator/validate_model.py
+++ b/semantic_model_generator/validate_model.py
@@ -39,7 +39,7 @@ def validate(yaml_path: str, snowflake_account: str) -> None:
                 _ = conn.cursor().execute(select)
             except Exception as e:
                 raise ValueError(
-                    f"Unable to execute query with your logical table against physical tables on Snowflake. Error = {e}"
+                    f"Unable to execute query with your base table against physical tables on Snowflake. Error = {e}"
                 )
             logger.info(f"Validated logical table: {table.name}")
 

--- a/semantic_model_generator/validate_model.py
+++ b/semantic_model_generator/validate_model.py
@@ -39,7 +39,7 @@ def validate(yaml_path: str, snowflake_account: str) -> None:
                 _ = conn.cursor().execute(select)
             except Exception as e:
                 raise ValueError(
-                    f"Unable to execute query with your base table against physical tables on Snowflake. Error = {e}"
+                    f"Unable to execute query with your logical table against base tables on Snowflake. Error = {e}"
                 )
             logger.info(f"Validated logical table: {table.name}")
 


### PR DESCRIPTION
In validation, throw an error if the user's semantic model as OBJECT datatype.