### PR TITLE
Rerun admin app upon saving semantic model

### DIFF
--- a/admin_apps/iteration_app.py
+++ b/admin_apps/iteration_app.py
@@ -426,6 +426,8 @@ def yaml_editor(yaml_str: str) -> None:
                 update_container(
                     status_container, "success", prefix=status_container_title
                 )
+                st.session_state.semantic_model = yaml_to_semantic_model(content)
+                st.session_state.last_saved_yaml = content
             except Exception as e:
                 st.session_state["validated"] = False
                 update_container(
@@ -433,8 +435,7 @@ def yaml_editor(yaml_str: str) -> None:
                 )
                 exception_as_dialog(e)
 
-            st.session_state.semantic_model = yaml_to_semantic_model(content)
-            st.session_state.last_saved_yaml = content
+            st.rerun()
         if right.button(
             "Upload",
             use_container_width=True,


### PR DESCRIPTION
When testing, I realized that editing the YAML manually, saving, then attempting to send a message would rerun the app on sending a message which was unintended.

Adding a specific rerun action when the YAML is saved so that the refresh does not occur upon saving the message.