### PR TITLE
Trigger lint/test workflows on additional files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - "semantic_model_generator/**"
-      - "admin_app/**"
+      - "admin_apps/**"
 
 jobs:
   build:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - "semantic_model_generator/**"
-      - "admin_apps/**"
 
 jobs:
   build:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "semantic_model_generator/**"
+      - "admin_apps/**"
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - "semantic_model_generator/**"
-      - "admin_apps/**"
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "semantic_model_generator/**"
+      - "admin_apps/**"
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "semantic_model_generator/**"
+      - "pyproject.toml"
 
 jobs:
   build:


### PR DESCRIPTION
The `lint` workflow should run when changing any admin_app code. This wasn't running because I renamed the directory.

Furthermore, I forgot to regen the `poetry.lock` file when editing `pyproject.toml`, and this wasn't caught because the build + test action only runs on the `semantic_model_generator/` dir. Including the toml file now to catch these omissions in the future. Since we don't have tests in `admin_apps/` for now we don't need to run the test script for that directory, but eventually we should.