### PR TITLE
Reuse Snowflake connection throughout Streamlit app

### DIFF
--- a/admin_apps/app.py
+++ b/admin_apps/app.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from snowflake.connector import DatabaseError
 
 from admin_apps.shared_utils import GeneratorAppScreen, get_snowflake_connection
 from semantic_model_generator.snowflake_utils.env_vars import (
@@ -27,6 +28,17 @@ Please follow the [setup instructions](https://github.com/Snowflake-Labs/semanti
     st.stop()
 
 
+@st.experimental_dialog(title="Connection Error")
+def failed_connection_popup() -> None:
+    """
+    Renders a dialog box detailing that the credentials provided could not be used to connect to Snowflake.
+    """
+    st.markdown(
+        f"""It looks like the credentials provided for `{SNOWFLAKE_USER}` could not be used to connect to the account `{SNOWFLAKE_ACCOUNT_LOCATOR}` at host `{SNOWFLAKE_HOST}`. Please verify your credentials in the environment variables and try again."""
+    )
+    st.stop()
+
+
 def verify_environment_setup() -> None:
     """
     Ensures that the correct environment variables are set before proceeding.
@@ -34,6 +46,12 @@ def verify_environment_setup() -> None:
     missing_env_vars = assert_required_env_vars()
     if missing_env_vars:
         env_setup_popup(missing_env_vars)
+
+    # Instantiate the Snowflake connection that gets reused throughout the app.
+    try:
+        get_snowflake_connection()
+    except DatabaseError:
+        failed_connection_popup()
 
 
 if __name__ == "__main__":

--- a/admin_apps/app.py
+++ b/admin_apps/app.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from admin_apps.shared_utils import GeneratorAppScreen
+from admin_apps.shared_utils import GeneratorAppScreen, get_snowflake_connection
 from semantic_model_generator.snowflake_utils.env_vars import (
     SNOWFLAKE_ACCOUNT_LOCATOR,
     SNOWFLAKE_HOST,
@@ -72,6 +72,7 @@ if __name__ == "__main__":
                 iteration.show()
 
     verify_environment_setup()
+    get_snowflake_connection()
 
     # Populating common state between builder and iteration apps.
     st.session_state["account_name"] = SNOWFLAKE_ACCOUNT_LOCATOR

--- a/admin_apps/app.py
+++ b/admin_apps/app.py
@@ -90,7 +90,6 @@ if __name__ == "__main__":
                 iteration.show()
 
     verify_environment_setup()
-    get_snowflake_connection()
 
     # Populating common state between builder and iteration apps.
     st.session_state["account_name"] = SNOWFLAKE_ACCOUNT_LOCATOR

--- a/admin_apps/journeys/builder.py
+++ b/admin_apps/journeys/builder.py
@@ -1,13 +1,10 @@
 import streamlit as st
 
-from admin_apps.journeys.iteration import get_connector
-from admin_apps.shared_utils import GeneratorAppScreen
+from admin_apps.shared_utils import GeneratorAppScreen, get_snowflake_connection
 from semantic_model_generator.generate_model import generate_model_str_from_snowflake
 from semantic_model_generator.snowflake_utils.snowflake_connector import (
     fetch_table_names,
 )
-
-connector = get_connector()
 
 
 @st.cache_resource(show_spinner=False)
@@ -18,8 +15,7 @@ def get_available_tables() -> list[str]:
     Returns: list of fully qualified table names
     """
 
-    with connector.connect(db_name="") as conn:
-        return fetch_table_names(conn)
+    return fetch_table_names(get_snowflake_connection())
 
 
 @st.experimental_dialog("Selecting your tables", width="large")
@@ -63,6 +59,7 @@ def table_selector_dialog() -> None:
                         snowflake_account=st.session_state["account_name"],
                         semantic_model_name=model_name,
                         n_sample_values=sample_values,  # type: ignore
+                        conn=get_snowflake_connection(),
                     )
 
                     # Set the YAML session state so that the iteration app has access to the generated contents,

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -16,6 +16,7 @@ from admin_apps.shared_utils import (
     add_logo,
     changed_from_last_validated_model,
     download_yaml,
+    get_snowflake_connection,
     init_session_states,
     upload_yaml,
     validate_and_upload_tmp_yaml,

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -38,20 +38,10 @@ from semantic_model_generator.snowflake_utils.env_vars import (
     SNOWFLAKE_USER,
 )
 from semantic_model_generator.snowflake_utils.snowflake_connector import (
-    SnowflakeConnector,
+    set_database,
+    set_schema,
 )
 from semantic_model_generator.validate_model import validate
-
-
-@st.cache_resource
-def get_connector() -> SnowflakeConnector:
-    return SnowflakeConnector(
-        account_name=SNOWFLAKE_ACCOUNT,
-        max_workers=1,
-    )
-
-
-connector = get_connector()
 
 
 def get_file_name() -> str:
@@ -178,17 +168,20 @@ def edit_verified_query(
                         user_updated_sql, st.session_state.ctx
                     )
 
-                    # TODO: figure out how to reuse the original connection, it's closed by this point
-                    with connector.connect(
-                        db_name=st.session_state.snowflake_stage.stage_database,
-                        schema_name=st.session_state.snowflake_stage.stage_schema,
-                    ) as connection:
-                        st.session_state["successful_sql"] = False
-                        df = pd.read_sql(sql_to_execute, connection)
-                        st.code(user_updated_sql)
-                        st.caption("**Output data**")
-                        st.dataframe(df)
-                        st.session_state["successful_sql"] = True
+                    connection = get_snowflake_connection()
+                    if "snowflake_stage" in st.session_state:
+                        set_database(
+                            connection, st.session_state.snowflake_stage.stage_database
+                        )
+                        set_schema(
+                            connection, st.session_state.snowflake_stage.stage_schema
+                        )
+                    st.session_state["successful_sql"] = False
+                    df = pd.read_sql(sql_to_execute, connection)
+                    st.code(user_updated_sql)
+                    st.caption("**Output data**")
+                    st.dataframe(df)
+                    st.session_state["successful_sql"] = True
 
                 except Exception as e:
                     st.session_state["error_state"] = (
@@ -345,13 +338,13 @@ def upload_dialog(content: str) -> None:
             with st.spinner(
                 "Your semantic model has changed since last validation. Re-validating before uploading..."
             ):
-                validate_and_upload_tmp_yaml()
+                validate_and_upload_tmp_yaml(conn=get_snowflake_connection())
 
         st.session_state.semantic_model = yaml_to_semantic_model(content)
         with st.spinner(
             f"Uploading @{st.session_state.snowflake_stage.stage_name}/{file_name}.yaml..."
         ):
-            upload_yaml(file_name)
+            upload_yaml(file_name, conn=get_snowflake_connection())
         st.success(
             f"Uploaded @{st.session_state.snowflake_stage.stage_name}/{file_name}.yaml!"
         )
@@ -452,7 +445,11 @@ def yaml_editor(yaml_str: str) -> None:
         if left.button("Save", use_container_width=True, help=SAVE_HELP):
             # Validate new content
             try:
-                validate(content, snowflake_account=st.session_state.account_name)
+                validate(
+                    content,
+                    snowflake_account=st.session_state.account_name,
+                    conn=get_snowflake_connection(),
+                )
                 st.session_state["validated"] = True
                 update_container(
                     status_container, "success", prefix=status_container_title
@@ -532,7 +529,7 @@ def show() -> None:
         add_logo()
         if "yaml" not in st.session_state:
             # Only proceed to download the YAML from stage if we don't have one from the builder flow.
-            yaml = download_yaml(st.session_state.file_name)
+            yaml = download_yaml(st.session_state.file_name, get_snowflake_connection())
             st.session_state["yaml"] = yaml
             st.session_state["semantic_model"] = yaml_to_semantic_model(yaml)
             if "last_saved_yaml" not in st.session_state:
@@ -556,5 +553,4 @@ def show() -> None:
         with chat_container:
             st.markdown("**Chat**")
             # We still initialize an empty connector and pass it down in order to propagate the connector auth token.
-            with connector.connect(db_name="") as conn:
-                chat_and_edit_vqr(conn)
+            chat_and_edit_vqr(get_snowflake_connection())

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -11,7 +11,6 @@ from streamlit.delta_generator import DeltaGenerator
 from streamlit_monaco import st_monaco
 
 from admin_apps.shared_utils import (
-    SNOWFLAKE_ACCOUNT,
     GeneratorAppScreen,
     SnowflakeStage,
     add_logo,

--- a/semantic_model_generator/generate_model.py
+++ b/semantic_model_generator/generate_model.py
@@ -320,7 +320,6 @@ def generate_base_semantic_model_from_snowflake(
         snowflake_account=snowflake_account,
         n_sample_values=n_sample_values if n_sample_values > 0 else 1,
         semantic_model_name=semantic_model_name,
-        conn=None,  # Instantiate a new connection.
     )
 
     with open(write_path, "w") as f:

--- a/semantic_model_generator/validate_model.py
+++ b/semantic_model_generator/validate_model.py
@@ -1,5 +1,6 @@
 import jsonargparse
 from loguru import logger
+from snowflake.connector import SnowflakeConnection
 
 from semantic_model_generator.data_processing.cte_utils import (
     context_to_column_format,
@@ -10,6 +11,8 @@ from semantic_model_generator.data_processing.cte_utils import (
 from semantic_model_generator.data_processing.proto_utils import yaml_to_semantic_model
 from semantic_model_generator.snowflake_utils.snowflake_connector import (
     SnowflakeConnector,
+    set_database,
+    set_schema,
 )
 from semantic_model_generator.validate.context_length import validate_context_length
 
@@ -25,7 +28,9 @@ def load_yaml(yaml_path: str) -> str:
     return yaml_str
 
 
-def validate(yaml_str: str, snowflake_account: str) -> None:
+def validate(
+    yaml_str: str, snowflake_account: str, conn: SnowflakeConnection = None
+) -> None:
     """
     For now, validate just ensures that the yaml is correctly formatted and we can parse into our protos.
 
@@ -39,51 +44,68 @@ def validate(yaml_str: str, snowflake_account: str) -> None:
     # Validate the context length doesn't exceed max we can support.
     validate_context_length(model, throw_error=True)
 
-    connector = SnowflakeConnector(
-        account_name=snowflake_account,
-        max_workers=1,
-    )
     model_in_column_format = context_to_column_format(model)
 
     for table in model_in_column_format.tables:
         logger.info(f"Checking logical table: {table.name}")
         # Each table can be a different database/schema.
         # Create new connection for each one.
-        with connector.connect(
-            db_name=table.base_table.database, schema_name=table.base_table.schema
-        ) as conn:
-            try:
-                validate_all_cols(table)
-                sqls = generate_select(table, 1)
-                # Run the query.
-                # TODO: some expr maybe expensive if contains aggregations or window functions. Move to EXPLAIN?
-                for sql in sqls:
-                    _ = conn.cursor().execute(sql)
-            except Exception as e:
-                raise ValueError(f"Unable to validate your semantic model. Error = {e}")
-            logger.info(f"Validated logical table: {table.name}")
+        if conn is None:
+            connector = SnowflakeConnector(
+                account_name=snowflake_account,
+                max_workers=1,
+            )
+            with connector.connect(
+                db_name=table.base_table.database, schema_name=table.base_table.schema
+            ) as unique_connection:
+                conn = unique_connection
+        else:
+            set_database(conn, table.base_table.database)
+            set_schema(conn, table.base_table.schema)
+        try:
+            validate_all_cols(table)
+            sqls = generate_select(table, 1)
+            # Run the query.
+            # TODO: some expr maybe expensive if contains aggregations or window functions. Move to EXPLAIN?
+            for sql in sqls:
+                _ = conn.cursor().execute(sql)
+        except Exception as e:
+            raise ValueError(f"Unable to validate your semantic model. Error = {e}")
+        logger.info(f"Validated logical table: {table.name}")
 
     for vq in model.verified_queries:
         logger.info(f"Checking verified queries for: {vq.question}")
-        with connector.connect(
-            db_name=table.base_table.database, schema_name=table.base_table.schema
-        ) as conn:
-            try:
-                vqr_with_ctes = expand_all_logical_tables_as_ctes(
-                    vq.sql, model_in_column_format
-                )
-                # Run the query
-                _ = conn.cursor().execute(vqr_with_ctes)
-            except Exception as e:
-                raise ValueError(f"Fail to validate your verified query. Error = {e}")
-            logger.info(f"Validated verified query: {vq.question}")
+        if conn is None:
+            connector = SnowflakeConnector(
+                account_name=snowflake_account,
+                max_workers=1,
+            )
+            with connector.connect(
+                db_name=table.base_table.database, schema_name=table.base_table.schema
+            ) as unique_connection:
+                conn = unique_connection
+        else:
+            set_database(conn, table.base_table.database)
+            set_schema(conn, table.base_table.schema)
+
+        try:
+            vqr_with_ctes = expand_all_logical_tables_as_ctes(
+                vq.sql, model_in_column_format
+            )
+            # Run the query
+            _ = conn.cursor().execute(vqr_with_ctes)
+        except Exception as e:
+            raise ValueError(f"Fail to validate your verified query. Error = {e}")
+        logger.info(f"Validated verified query: {vq.question}")
 
     logger.info("Successfully validated!")
 
 
-def validate_from_local_path(yaml_path: str, snowflake_account: str) -> None:
+def validate_from_local_path(
+    yaml_path: str, snowflake_account: str, conn: SnowflakeConnection
+) -> None:
     yaml_str = load_yaml(yaml_path)
-    validate(yaml_str, snowflake_account)
+    validate(yaml_str, snowflake_account, conn)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves https://github.com/Snowflake-Labs/semantic-model-generator/issues/90, https://github.com/Snowflake-Labs/semantic-model-generator/issues/97

In the current version of the admin app, we manually instantiate a `SnowflakeConnection` multiple times throughout the codebase. This isn't particularly a problem when the user is using standard username/pw credentials; however, when using MFA or external-browser authentication, this causes multiple pings/browser windows to pop up, which interrupts the UX significantly.

I've modified the Streamlit app to instantiate a single top-level Snowflake connection and cached it via `st.cache_resource`. With Streamlit's caching, whenever the decorated function is run for the very first time in the lifetime of the app, the connection is created and stored in cache. Whenever the function is invoked again, the connection is retrieved from cache instead of instantiated from scratch. See https://docs.streamlit.io/develop/concepts/architecture/caching#stcache_resource for more details.

I also had to make some changes to the underlying model generation/validation logic so that a connection can optionally be passed in instead of instantiating new connections.


## Testing

Use the app with a user/account that uses the `externalbrowser` authenticator type. Verify that you see a single auth popup on app start, and only once. Verify that you do not see any more popups while using the app.

 