### PR TITLE
Mark SNOWFLAKE_HOST as a required env var for Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Or, if you want to see what a semantic model looks like, skip to [Examples](#exa
 
 ## Setup
 
-We currently leverage credentials saved as environment variables. Note, `host` is optional depending on your Snowflake
-deployment.
+We currently leverage credentials saved as environment variables.
 
 A. To find your Account locator, please execute the following sql command in your account.
 
@@ -29,6 +28,8 @@ account, [follow these instructions](https://docs.snowflake.com/en/user-guide/or
 * Currently we recommend you to look under the `Account locator (legacy)` method of connection for better compatibility
   on API.
 * It typically follows format of: `https://<accountlocator>.<region>.<cloud>.snowflakecomputing.com`
+* `SNOWFLAKE_HOST` is required if you are using the Streamlit app, but may not be required for the CLI tool depending on
+  your Snowflake deployment. We would recommend setting it regardless.
 
 
 1. To set these on Mac OS/Linux:

--- a/semantic_model_generator/snowflake_utils/env_vars.py
+++ b/semantic_model_generator/snowflake_utils/env_vars.py
@@ -5,7 +5,7 @@ SNOWFLAKE_ROLE = os.getenv("SNOWFLAKE_ROLE")
 SNOWFLAKE_WAREHOUSE = os.getenv("SNOWFLAKE_WAREHOUSE")
 SNOWFLAKE_USER = os.getenv("SNOWFLAKE_USER")
 SNOWFLAKE_PASSWORD = os.getenv("SNOWFLAKE_PASSWORD")
-SNOWFLAKE_HOST = os.getenv("SNOWFLAKE_HOST")  # optional per README docs
+SNOWFLAKE_HOST = os.getenv("SNOWFLAKE_HOST")
 SNOWFLAKE_AUTHENTICATOR = os.getenv("SNOWFLAKE_AUTHENTICATOR")
 SNOWFLAKE_ACCOUNT_LOCATOR = os.getenv("SNOWFLAKE_ACCOUNT_LOCATOR")
 
@@ -26,6 +26,8 @@ def assert_required_env_vars() -> list[str]:
         missing_env_vars.append("SNOWFLAKE_USER")
     if not SNOWFLAKE_ACCOUNT_LOCATOR:
         missing_env_vars.append("SNOWFLAKE_ACCOUNT_LOCATOR")
+    if not SNOWFLAKE_HOST:
+        missing_env_vars.append("SNOWFLAKE_HOST")
     if not SNOWFLAKE_PASSWORD and not SNOWFLAKE_AUTHENTICATOR:
         missing_env_vars.append("SNOWFLAKE_PASSWORD/SNOWFLAKE_AUTHENTICATOR")
 


### PR DESCRIPTION
In the README we have `SNOWFLAKE_HOST` marked as optional, which is only true for the CLI tool; we need the host in order to properly call the Analyst API for the VQR app.

Clarifying this in the README and marking it as required in our app codepaths.

![CleanShot 2024-07-26 at 15 05 17](https://github.com/user-attachments/assets/4b9c3dc8-5b1f-445b-9f12-f27ae4517ec8)

