### PR TITLE
Dropdown selectors for iteration flow

### DIFF
--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -517,26 +517,19 @@ def stage_selector_container() -> None:
     When a db/schema/stage is selected, it is saved to the session state for reading elsewhere.
     Returns: None
     """
-    if "selected_iteration_database" not in st.session_state:
-        st.session_state["selected_iteration_database"] = ""
-
-    if "selected_iteration_schema" not in st.session_state:
-        st.session_state["selected_iteration_schema"] = ""
-
-    if "selected_iteration_stage" not in st.session_state:
-        st.session_state["selected_iteration_stage"] = ""
-
     available_schemas = []
     available_stages = []
 
     # First, retrieve all databases that the user has access to.
     stage_database = st.selectbox(
-        "Stage database", options=get_available_databases(), index=None
+        "Stage database",
+        options=get_available_databases(),
+        index=None,
+        key="selected_iteration_database",
     )
     if stage_database:
         # When a valid database is selected, fetch the available schemas in that database.
         try:
-            st.session_state["selected_iteration_database"] = stage_database
             set_database(get_snowflake_connection(), stage_database)
             available_schemas = get_available_schemas(stage_database)
         except (ValueError, ProgrammingError):
@@ -547,19 +540,23 @@ def stage_selector_container() -> None:
         "Stage schema",
         options=available_schemas,
         index=None,
+        key="selected_iteration_schema",
     )
     if stage_schema:
         # When a valid schema is selected, fetch the available stages in that schema.
         try:
-            st.session_state["selected_iteration_schema"] = stage_schema
             set_schema(get_snowflake_connection(), stage_schema)
             available_stages = get_available_stages(stage_schema)
         except (ValueError, ProgrammingError):
             st.error("Insufficient permissions to read from the selected schema.")
             st.stop()
 
-    stage_name = st.selectbox("Stage name", options=available_stages, index=None)
-    st.session_state["selected_iteration_stage"] = stage_name
+    st.selectbox(
+        "Stage name",
+        options=available_stages,
+        index=None,
+        key="selected_iteration_stage",
+    )
 
 
 @st.experimental_dialog("Welcome to the Iteration app! 💬", width="large")

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -517,6 +517,15 @@ def stage_selector_container() -> None:
     When a db/schema/stage is selected, it is saved to the session state for reading elsewhere.
     Returns: None
     """
+    if "selected_iteration_database" not in st.session_state:
+        st.session_state["selected_iteration_database"] = ""
+
+    if "selected_iteration_schema" not in st.session_state:
+        st.session_state["selected_iteration_schema"] = ""
+
+    if "selected_iteration_stage" not in st.session_state:
+        st.session_state["selected_iteration_stage"] = ""
+
     available_schemas = []
     available_stages = []
 
@@ -561,15 +570,6 @@ def set_up_requirements() -> None:
     st.markdown(
         "Fill in the Snowflake stage details to download your existing YAML file."
     )
-
-    if "selected_iteration_database" not in st.session_state:
-        st.session_state["selected_iteration_database"] = ""
-
-    if "selected_iteration_schema" not in st.session_state:
-        st.session_state["selected_iteration_schema"] = ""
-
-    if "selected_iteration_stage" not in st.session_state:
-        st.session_state["selected_iteration_stage"] = ""
 
     stage_selector_container()
 

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -374,13 +374,16 @@ def upload_dialog(content: str) -> None:
         stage_selector_container()
         new_name = st.text_input("File name (omit .yaml suffix)", value="")
 
-        if st.button(
-            "Submit Upload",
-            disabled=not st.session_state["selected_iteration_database"]
-            or not st.session_state["selected_iteration_schema"]
-            or not st.session_state["selected_iteration_stage"]
-            or not new_name,
-        ):
+        if st.button("Submit Upload"):
+            if (
+                not st.session_state["selected_iteration_database"]
+                or not st.session_state["selected_iteration_schema"]
+                or not st.session_state["selected_iteration_stage"]
+                or not new_name
+            ):
+                st.error("Please fill in all fields.")
+                return
+
             st.session_state["snowflake_stage"] = SnowflakeStage(
                 stage_database=st.session_state["selected_iteration_database"],
                 stage_schema=st.session_state["selected_iteration_schema"],

--- a/semantic_model_generator/snowflake_utils/snowflake_connector.py
+++ b/semantic_model_generator/snowflake_utils/snowflake_connector.py
@@ -305,6 +305,43 @@ def fetch_tables_views_in_schema(
     return results
 
 
+def fetch_stages_in_schema(conn: SnowflakeConnection, schema_name: str) -> list[str]:
+    """
+    Fetches all stages that the current user has access to in the current schema
+    Args:
+        conn: SnowflakeConnection to run the query
+        schema_name: The name of the schema to connect to.
+
+    Returns: a list of fully qualified stage names
+    """
+
+    query = f"show stages in schema {schema_name};"
+    cursor = conn.cursor()
+    cursor.execute(query)
+    stages = cursor.fetchall()
+
+    return [f"{result[2]}.{result[3]}.{result[1]}" for result in stages]
+
+
+def fetch_yaml_names_in_stage(conn: SnowflakeConnection, stage_name: str) -> list[str]:
+    """
+    Fetches all yaml files that the current user has access to in the current stage
+    Args:
+        conn: SnowflakeConnection to run the query
+        stage_name: The fully qualified name of the stage to connect to.
+
+    Returns: a list of yaml file names
+    """
+
+    query = f"list @{stage_name} pattern='.*\\.yaml';"
+    cursor = conn.cursor()
+    cursor.execute(query)
+    yaml_files = cursor.fetchall()
+
+    # The file name is prefixed with "@{stage_name}/", so we need to remove that prefix.
+    return [result[0].split("/")[-1] for result in yaml_files]
+
+
 def get_valid_schemas_tables_columns_df(
     conn: SnowflakeConnection,
     table_schema: Optional[str] = None,


### PR DESCRIPTION
Replaces the free text entry fields in the iteration flow with dropdowns, so that the user can click to select their file instead of having to type everything in manually. This fully completes #94 .

## Testing
Go through the iteration flow and verify functionality of the dropdown selectors. Proceed to use the app and upload your YAML to a stage.

Additionally, go through the builder flow, and verify that the step where you select the Snowflake stage at the end works with the new dropdown selectors.