### PR TITLE
Add local download button

### DIFF
--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -450,8 +450,12 @@ def yaml_editor(yaml_str: str) -> None:
     status_container = st.empty()
 
     with button_container:
-        left, right, _ = st.columns((1, 1, 2))
-        if left.button("Save", use_container_width=True, help=SAVE_HELP):
+        (
+            left,
+            middle,
+            right,
+        ) = st.columns(3)
+        if left.button("Validate", use_container_width=True, help=VALIDATE_HELP):
             # Validate new content
             try:
                 validate(
@@ -472,6 +476,16 @@ def yaml_editor(yaml_str: str) -> None:
                     status_container, "failed", prefix=status_container_title
                 )
                 exception_as_dialog(e)
+
+        if content:
+            middle.download_button(
+                label="Download",
+                data=content,
+                file_name="semantic_model.yaml",
+                mime="text/yaml",
+                use_container_width=True,
+                help=DOWNLOAD_HELP,
+            )
 
         if right.button(
             "Upload",
@@ -610,8 +624,12 @@ def set_up_requirements() -> None:
         st.rerun()
 
 
-SAVE_HELP = """Save changes to the active semantic model in this app. This is
+VALIDATE_HELP = """Save and validate changes to the active semantic model in this app. This is
 useful so you can then play with it in the chat panel on the right side."""
+
+DOWNLOAD_HELP = (
+    """Download the currently loaded semantic model to your local machine."""
+)
 
 UPLOAD_HELP = """Upload the YAML to the Snowflake stage. You want to do that whenever
 you think your semantic model is doing great and should be pushed to prod! Note that

--- a/semantic_model_generator/snowflake_utils/env_vars.py
+++ b/semantic_model_generator/snowflake_utils/env_vars.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(override=True)
 DEFAULT_SESSION_TIMEOUT_SEC = int(os.environ.get("SNOWFLAKE_SESSION_TIMEOUT_SEC", 120))
 SNOWFLAKE_ROLE = os.getenv("SNOWFLAKE_ROLE")
 SNOWFLAKE_WAREHOUSE = os.getenv("SNOWFLAKE_WAREHOUSE")


### PR DESCRIPTION
If users run into a fatal error when uploading, there's no easy way to save their progress locally. I've added a Download button so that users can at least obtain a local copy of their work should the upload not be functional.

![CleanShot 2024-08-01 at 13 31 35](https://github.com/user-attachments/assets/a3639a5e-aa8f-4675-b020-945eca8419f7)
