### PR TITLE
Fix rerun bug when saving semantic models

### DIFF
--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -465,13 +465,20 @@ def yaml_editor(yaml_str: str) -> None:
                 )
                 st.session_state.semantic_model = yaml_to_semantic_model(content)
                 st.session_state.last_saved_yaml = content
-                st.rerun()
             except Exception as e:
                 st.session_state["validated"] = False
                 update_container(
                     status_container, "failed", prefix=status_container_title
                 )
                 exception_as_dialog(e)
+
+            # Rerun the app if validation was successful.
+            # We shouldn't rerun if validation failed as the error popup would immediately dismiss.
+            # This must be done outside of the try/except because the generic Exception handling is catching the
+            # exception that st.rerun() properly raises to halt execution.
+            # This is fixed in later versions of Streamlit, but other refactors to the code are required to upgrade.
+            if st.session_state["validated"]:
+                st.rerun()
 
         if right.button(
             "Upload",


### PR DESCRIPTION
Some users reported that saving a semantic model would immediately result in an error that seemed to be Streamlit-specific: `RerunData(page_script_hash=...)`

It seems that there is a bug with the version of Streamlit that we are using where `st.rerun()` is throwing a generic Exception - this is in theory fine behavior since `rerun()` needs to throw an exception to halt the process, but this causes issues when being called within a `try/except Exception...` block.

This has been patched by Streamlit but not pushed to a new release yet; additionally, upgrading would require a few more refactors. For now I'm simply fixing this by moving the rerun() outside of the try/except block.