### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ account, [follow these instructions](https://docs.snowflake.com/en/user-guide/or
 
 * Currently we recommend you to look under the `Account locator (legacy)` method of connection for better compatibility
   on API.
-* It typically follows format of: `https://<accountlocator>.<region>.<cloud>.snowflakecomputing.com`
+* It typically follows format of: `<accountlocator>.<region>.<cloud>.snowflakecomputing.com`. Ensure that you omit the `https://` prefix.
 * `SNOWFLAKE_HOST` is required if you are using the Streamlit app, but may not be required for the CLI tool depending on
   your Snowflake deployment. We would recommend setting it regardless.
 


### PR DESCRIPTION
A couple SEs have ran into this, where specifying `https://` in the snowflake host messes up SSO signin as well as the API url. Making it more clear that `https://` shouldn't be included.