### PR TITLE
Mark `looker_sdk` as an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ make run_admin_app
 python3.11 -m streamlit run admin_apps/app.py
 ```
 
+### Partner Support
+
+The generator supports merging data from your existing semantic models built with partners such as dbt and Looker. To
+use the Looker features, please install the extras:
+
+```bash
+pip install -e ".[looker]"
+```
+
 ## CLI Tool
 
 You may also generate a semantic model directly from the CLI. To do this, first install the CLI tool dependencies, which

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -10,7 +10,6 @@ from snowflake.connector import ProgrammingError, SnowflakeConnection
 from streamlit.delta_generator import DeltaGenerator
 from streamlit_monaco import st_monaco
 
-from admin_apps.partner.partner_utils import integrate_partner_semantics
 from admin_apps.shared_utils import (
     GeneratorAppScreen,
     SnowflakeStage,
@@ -500,6 +499,8 @@ def yaml_editor(yaml_str: str) -> None:
         ):
             upload_dialog(content)
         if st.session_state.get("partner_setup", False):
+            from admin_apps.partner.partner_utils import integrate_partner_semantics
+
             if four.button(
                 "Integrate Partner",
                 use_container_width=True,

--- a/admin_apps/journeys/partner.py
+++ b/admin_apps/journeys/partner.py
@@ -1,13 +1,12 @@
 import streamlit as st
 
-from admin_apps.partner.partner_utils import configure_partner_semantic
-
 
 @st.dialog("Partner Semantic Support", width="large")
 def partner_semantic_setup() -> None:
     """
     Renders the partner semantic setup dialog with instructions.
     """
+    from admin_apps.partner.partner_utils import configure_partner_semantic
 
     st.write(
         """

--- a/admin_apps/partner/looker.py
+++ b/admin_apps/partner/looker.py
@@ -1,11 +1,8 @@
 import os
 from typing import Any, Optional
-
-import looker_sdk
 import pandas as pd
 import streamlit as st
 from loguru import logger
-from looker_sdk import models40 as models
 from snowflake.connector import ProgrammingError, SnowflakeConnection
 
 from admin_apps.partner.cortex import (
@@ -30,6 +27,16 @@ from admin_apps.shared_utils import (
     set_table_comment,
 )
 from semantic_model_generator.data_processing.proto_utils import proto_to_dict
+
+try:
+    import looker_sdk
+    from looker_sdk import models40 as models
+except ImportError:
+    raise ImportError(
+        "The looker extra is required. You can install it using pip:\n\n"
+        "pip install -e '.[looker]'\n"
+    )
+
 
 # Partner semantic support instructions
 LOOKER_IMAGE = "admin_apps/images/looker.png"
@@ -286,7 +293,13 @@ def set_looker_config() -> looker_sdk.sdk.api40.methods.Looker40SDK:
     Sets Looker SDK connection
     """
 
-    import looker_sdk
+    try:
+        import looker_sdk
+    except ImportError:
+        raise ImportError(
+            "The looker extra is required. You can install it using pip:\n\n"
+            "pip install -e '.[looker]'\n"
+        )
 
     os.environ["LOOKERSDK_BASE_URL"] = st.session_state[
         "looker_base_url"
@@ -295,7 +308,8 @@ def set_looker_config() -> looker_sdk.sdk.api40.methods.Looker40SDK:
         "4.0"  # As of Looker v23.18+, the 3.0 and 3.1 versions of the API are removed. Use "4.0" here.
     )
     os.environ["LOOKERSDK_VERIFY_SSL"] = (
-        "true"  # Defaults to true if not set. SSL verification should generally be on unless you have a real good reason not to use it. Valid options: true, y, t, yes, 1.
+        "true"
+        # Defaults to true if not set. SSL verification should generally be on unless you have a real good reason not to use it. Valid options: true, y, t, yes, 1.
     )
     os.environ["LOOKERSDK_TIMEOUT"] = (
         "120"  # Seconds till request timeout. Standard default is 120.

--- a/admin_apps/partner/looker.py
+++ b/admin_apps/partner/looker.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Optional
+
 import pandas as pd
 import streamlit as st
 from loguru import logger

--- a/admin_apps/partner/partner_utils.py
+++ b/admin_apps/partner/partner_utils.py
@@ -9,7 +9,6 @@ import yaml
 
 from admin_apps.partner.cortex import CortexSemanticTable
 from admin_apps.partner.dbt import DBTSemanticModel, upload_dbt_semantic
-from admin_apps.partner.looker import LookerSemanticTable, set_looker_semantic
 from admin_apps.shared_utils import (
     get_snowflake_connection,
     render_image,
@@ -75,6 +74,8 @@ def configure_partner_semantic() -> None:
     if st.session_state["partner_tool"] == "dbt":
         upload_dbt_semantic()
     if st.session_state["partner_tool"] == "looker":
+        from admin_apps.partner.looker import set_looker_semantic
+
         set_looker_semantic()
 
 
@@ -251,7 +252,10 @@ def integrate_partner_semantics() -> None:
     if st.session_state.get("partner_setup", False):
         # Execute pre-processing behind the scenes based on vendor tool
         CortexSemanticTable.create_cortex_table_list()
+
         if st.session_state.get("selected_partner", None) == "looker":
+            from admin_apps.partner.looker import LookerSemanticTable
+
             LookerSemanticTable.create_cortex_table_list()
         elif st.session_state.get("selected_partner", None) == "dbt":
             pass
@@ -300,6 +304,8 @@ def integrate_partner_semantics() -> None:
             )
 
             if st.session_state.get("selected_partner", None) == "looker":
+                from admin_apps.partner.looker import LookerSemanticTable
+
                 partner_fields_df = LookerSemanticTable.retrieve_df_by_name(
                     semantic_partner_tbl
                 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -172,7 +172,7 @@ files = [
 name = "cattrs"
 version = "24.1.0"
 description = "Composable complex class support for attrs and dataclasses."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "cattrs-24.1.0-py3-none-any.whl", hash = "sha256:043bb8af72596432a7df63abcff0055ac0f198a4d2e95af8db5a936a7074a761"},
@@ -1155,7 +1155,7 @@ dev = ["Sphinx (==7.2.5)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptio
 name = "looker-sdk"
 version = "24.14.0"
 description = "Looker REST API"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "looker_sdk-24.14.0-py3-none-any.whl", hash = "sha256:81f75bd77330193e8870da0327da7eb350d72e11a69d86bd2f0d6cb2510c83d5"},
@@ -2271,13 +2271,13 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "8.3.2"
+version = "8.3.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5"},
-    {file = "pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"},
+    {file = "pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"},
+    {file = "pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181"},
 ]
 
 [package.dependencies]
@@ -2441,13 +2441,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
-version = "13.8.0"
+version = "13.8.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.8.0-py3-none-any.whl", hash = "sha256:2e85306a063b9492dffc86278197a60cbece75bcb766022f3436f567cae11bdc"},
-    {file = "rich-13.8.0.tar.gz", hash = "sha256:a5ac1f1cd448ade0d59cc3356f7db7a7ccda2c8cbae9c7a90c28ff463d3e91f4"},
+    {file = "rich-13.8.1-py3-none-any.whl", hash = "sha256:1760a3c0848469b97b558fc61c85233e3dafb69c7a071b4d60c38099d3cd4c06"},
+    {file = "rich-13.8.1.tar.gz", hash = "sha256:8260cda28e3db6bf04d2d1ef4dbc03ba80a824c88b0e7668a0f23126a424844a"},
 ]
 
 [package.dependencies]
@@ -3275,7 +3275,10 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
+[extras]
+looker = ["looker-sdk"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.9.7 || >3.9.7,<3.12"
-content-hash = "b65d3be55fa96a624c846f8982137a1267cffba64849df4f2eb67b8796c630a9"
+content-hash = "18363e209a32f2941a1a77ed592ddc607286d15bcde20d798dbfd5e9100d9c16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ numpy = "^1.24.4"
 python-dotenv = "^1.0.1"
 urllib3 = "^1.26.19"
 requests = "^2.32.3"
-looker-sdk = "^24.14.0"
+
+# Optional dependencies for functionality such as partner semantic model support.
+looker-sdk = { version = "^24.14.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.9.0"
@@ -38,6 +40,9 @@ pytest = "^8.1.1"
 types-pyyaml = "^6.0.12.20240311"
 types-protobuf = "^4.24.0.20240311"
 pip-licenses = "^4.4.0"
+
+[tool.poetry.extras]
+looker = ["looker-sdk"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Some users may not want to run through partner flows, in which case installing the Looker SDK is unnecessary. Following the discussion in https://github.com/Snowflake-Labs/semantic-model-generator/pull/150#issuecomment-2340560372, this PR moves `looker-sdk` into the "extra" dependencies section, meaning it won't be installed unless specified (e.g. `poetry install -E looker`).

To support this, I made some small refactors to only import looker conditionally. The popup will now be triggered if the user attempts to click the "Start with partner semantic model" button.

Shown below is a video showing that without looker installed, the rest of the app is functional, and a warning pops up if a user attempts to use the Looker integration without the SDK.

https://github.com/user-attachments/assets/5703dc60-948c-4b14-b94d-fa368637790f

