### PR TITLE
Clarify sample value selector during semantic model creation

### DIFF
--- a/admin_apps/shared_utils.py
+++ b/admin_apps/shared_utils.py
@@ -1018,8 +1018,8 @@ def input_sample_value_num() -> int:
     sample_values: int = st.selectbox(  # type: ignore
         "Maximum number of sample values per column",
         list(range(1, 40)),
-        index=0,
-        help="NOTE: For dimensions, time measures, and measures, we enforce a minimum of 25, 3, and 3 sample values respectively.",
+        index=2,
+        help="Specifies the maximum number of distinct sample values we fetch for each column.",
     )
     return sample_values
 

--- a/admin_apps/shared_utils.py
+++ b/admin_apps/shared_utils.py
@@ -1019,7 +1019,7 @@ def input_sample_value_num() -> int:
         "Maximum number of sample values per column",
         list(range(1, 40)),
         index=2,
-        help="Specifies the maximum number of distinct sample values we fetch for each column.",
+        help="Specifies the maximum number of distinct sample values we fetch for each column. We suggest keeping this number as low as possible to reduce latency.",
     )
     return sample_values
 

--- a/semantic_model_generator/snowflake_utils/snowflake_connector.py
+++ b/semantic_model_generator/snowflake_utils/snowflake_connector.py
@@ -133,19 +133,6 @@ def get_table_representation(
 ) -> Table:
     table_comment = _get_table_comment(conn, table_name, columns_df)
 
-    def _get_ndv_per_column(column_row: pd.Series, ndv_per_column: int) -> int:
-        data_type = column_row[_DATATYPE_COL]
-        data_type = data_type.split("(")[0].strip().upper()
-        if data_type in DIMENSION_DATATYPES:
-            # For dimension columns, we will by default fetch at least 25 distinct values
-            # As we index all dimensional column sample values by default.
-            return max(25, ndv_per_column)
-        if data_type in TIME_MEASURE_DATATYPES:
-            return max(3, ndv_per_column)
-        if data_type in MEASURE_DATATYPES:
-            return max(3, ndv_per_column)
-        return ndv_per_column
-
     def _get_col(col_index: int, column_row: pd.Series) -> Column:
         return _get_column_representation(
             conn=conn,
@@ -153,7 +140,7 @@ def get_table_representation(
             table_name=table_name,
             column_row=column_row,
             column_index=col_index,
-            ndv=_get_ndv_per_column(column_row, ndv_per_column),
+            ndv=ndv_per_column,
         )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:


### PR DESCRIPTION
The previous behavior of the sample value dropdown was a bit confusing.

Old behavior: depending on the column type, we take `max(hardcoded_column_sample_value_ct, user input)` to determine the number of sample values fetched. This was a bit misleading because a user would select "1" but would still see 25 sample values for certain columns, since 25 was hardcoded.

New behavior: sample value dropdown is the source of truth; we remove the hardcoded values so that whatever is selected is the actual maximum we use for each column. The default number of sample values fetched is now 3.

See in the screenshots below that selecting "3" now applies the maximum properly.
 
![CleanShot 2024-09-13 at 13 18 08](https://github.com/user-attachments/assets/f903b480-9d74-4f77-8228-acbe12d440ed)

![CleanShot 2024-09-13 at 13 18 34](https://github.com/user-attachments/assets/ed5ed9ff-b3bb-466e-b2ab-2f48b2d4df19)
