### PR TITLE
UI for editing join keys

### DIFF
--- a/admin_apps/journeys/builder.py
+++ b/admin_apps/journeys/builder.py
@@ -121,6 +121,7 @@ def table_selector_dialog() -> None:
         help="Checking this box will enable generation of experimental features in the semantic model. If enabling this setting, please ensure that you have the proper parameters set on your Snowflake account. Some features (e.g. joins) are currently in Private Preview and available only to select accounts. Reach out to your account team for access.",
     )
     allow_joins = False
+    st.session_state["experimental_features"] = False
     if experimental_features:
         allow_joins = True
         st.session_state["experimental_features"] = True

--- a/admin_apps/journeys/builder.py
+++ b/admin_apps/journeys/builder.py
@@ -120,11 +120,8 @@ def table_selector_dialog() -> None:
         "Enable experimental features (optional)",
         help="Checking this box will enable generation of experimental features in the semantic model. If enabling this setting, please ensure that you have the proper parameters set on your Snowflake account. Some features (e.g. joins) are currently in Private Preview and available only to select accounts. Reach out to your account team for access.",
     )
-    allow_joins = False
-    st.session_state["experimental_features"] = False
-    if experimental_features:
-        allow_joins = True
-        st.session_state["experimental_features"] = True
+
+    st.session_state["experimental_features"] = experimental_features
 
     submit = st.button("Submit", use_container_width=True, type="primary")
     if submit:
@@ -132,7 +129,7 @@ def table_selector_dialog() -> None:
             model_name,
             sample_values,
             st.session_state["selected_tables"],
-            allow_joins=allow_joins,
+            allow_joins=experimental_features,
         )
         st.session_state["page"] = GeneratorAppScreen.ITERATION
         st.rerun()

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -453,9 +453,7 @@ def yaml_editor(yaml_str: str) -> None:
     status_container_title = "**Edit**"
     status_container = st.empty()
 
-    if button_container.button(
-        "Validate", use_container_width=True, help=VALIDATE_HELP
-    ):
+    def validate_and_update_session_state() -> None:
         # Validate new content
         try:
             validate(
@@ -471,6 +469,11 @@ def yaml_editor(yaml_str: str) -> None:
             st.session_state["validated"] = False
             update_container(status_container, "failed", prefix=status_container_title)
             exception_as_dialog(e)
+
+    if button_container.button(
+        "Validate", use_container_width=True, help=VALIDATE_HELP
+    ):
+        validate_and_update_session_state()
 
         # Rerun the app if validation was successful.
         # We shouldn't rerun if validation failed as the error popup would immediately dismiss.
@@ -512,6 +515,8 @@ def yaml_editor(yaml_str: str) -> None:
             "Join Editor",
             use_container_width=True,
         ):
+            with st.spinner("Validating your model..."):
+                validate_and_update_session_state()
             joins_dialog()
 
     # Render the validation state (success=True, failed=False, editing=None) in the editor.
@@ -626,6 +631,11 @@ def set_up_requirements() -> None:
 
     file_name = st.selectbox("File name", options=available_files, index=None)
 
+    experimental_features = st.checkbox(
+        "Enable experimental features (optional)",
+        help="Checking this box will enable generation of experimental features in the semantic model. If enabling this setting, please ensure that you have the proper parameters set on your Snowflake account. Some features (e.g. joins) are currently in Private Preview and available only to select accounts. Reach out to your account team for access.",
+    )
+
     if st.button(
         "Submit",
         disabled=not st.session_state["selected_iteration_database"]
@@ -643,6 +653,7 @@ def set_up_requirements() -> None:
         st.session_state["user_name"] = SNOWFLAKE_USER
         st.session_state["file_name"] = file_name
         st.session_state["page"] = GeneratorAppScreen.ITERATION
+        st.session_state["experimental_features"] = experimental_features
         st.rerun()
 
 

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -507,11 +507,12 @@ def yaml_editor(yaml_str: str) -> None:
         ):
             integrate_partner_semantics()
 
-    if button_container.button(
-        "Join Editor",
-        use_container_width=True,
-    ):
-        joins_dialog()
+    if st.session_state.experimental_features:
+        if button_container.button(
+            "Join Editor",
+            use_container_width=True,
+        ):
+            joins_dialog()
 
     # Render the validation state (success=True, failed=False, editing=None) in the editor.
     if st.session_state.validated:

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -511,7 +511,6 @@ def yaml_editor(yaml_str: str) -> None:
         "Add joins",
         use_container_width=True,
     ):
-        st.session_state.builder_joins = st.session_state.semantic_model.relationships
         joins_dialog()
 
     # Render the validation state (success=True, failed=False, editing=None) in the editor.

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -508,7 +508,7 @@ def yaml_editor(yaml_str: str) -> None:
             integrate_partner_semantics()
 
     if button_container.button(
-        "Add joins",
+        "Join Editor",
         use_container_width=True,
     ):
         joins_dialog()

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -511,6 +511,7 @@ def yaml_editor(yaml_str: str) -> None:
         "Add joins",
         use_container_width=True,
     ):
+        st.session_state.builder_joins = st.session_state.semantic_model.relationships
         joins_dialog()
 
     # Render the validation state (success=True, failed=False, editing=None) in the editor.

--- a/admin_apps/journeys/joins.py
+++ b/admin_apps/journeys/joins.py
@@ -6,12 +6,11 @@ from semantic_model_generator.protos import semantic_model_pb2
 @st.dialog("Join Builder", width="large")
 def joins_dialog() -> None:
 
-    if "builder_joins" not in st.session_state:
-        st.session_state.builder_joins = st.session_state.semantic_model.relationships
-
     # For each relationship, render a relationship builder
     for idx, relationship in enumerate(st.session_state.builder_joins):
-        with st.expander(f"Join {idx}"):
+        with st.expander(relationship.name or f"Join {idx}"):
+            name = st.text_input("Name", value=relationship.name, key=f"name_{idx}")
+            relationship.name = name
             try:
                 default_left_table = [
                     table.name for table in st.session_state.semantic_model.tables
@@ -133,6 +132,7 @@ def joins_dialog() -> None:
                         right_column="",
                     )
                 )
+                st.rerun(scope="fragment")
 
     # If the user clicks "Add join", add a new join to the relationships list
     if st.button("Add join"):
@@ -145,6 +145,7 @@ def joins_dialog() -> None:
                 relationship_columns=[],
             )
         )
+        st.rerun(scope="fragment")
 
     # If the user clicks "Save", save the relationships list to the session state
     if st.button("Save"):
@@ -152,4 +153,4 @@ def joins_dialog() -> None:
         st.session_state.semantic_model.relationships.extend(
             st.session_state.builder_joins
         )
-        st.rerun()
+        st.rerun(scope="app")

--- a/admin_apps/journeys/joins.py
+++ b/admin_apps/journeys/joins.py
@@ -1,0 +1,134 @@
+import streamlit as st
+
+from semantic_model_generator.protos import semantic_model_pb2
+
+
+@st.dialog("Join Builder", width="large")
+def joins_dialog() -> None:
+
+    if "builder_joins" not in st.session_state:
+        st.session_state.builder_joins = st.session_state.semantic_model.relationships
+
+    # For each relationship, render a relationship builder
+    for idx, relationship in enumerate(st.session_state.builder_joins):
+        with st.expander(f"Join {idx}"):
+            try:
+                default_left_table = [
+                    table.name for table in st.session_state.semantic_model.tables
+                ].index(relationship.left_table)
+                default_right_table = [
+                    table.name for table in st.session_state.semantic_model.tables
+                ].index(relationship.right_table)
+            except ValueError:
+                default_left_table = 0
+                default_right_table = 0
+            left_table = st.selectbox(
+                "Left Table",
+                options=[
+                    table.name for table in st.session_state.semantic_model.tables
+                ],
+                index=default_left_table,
+                key=f"left_table_{idx}",
+            )
+
+            right_table = st.selectbox(
+                "Right Table",
+                options=[
+                    table.name for table in st.session_state.semantic_model.tables
+                ],
+                index=default_right_table,
+                key=f"right_table_{idx}",
+            )
+
+            join_type = st.selectbox(
+                "Join Type",
+                options=["inner", "left_outer"],
+                index=relationship.join_type,
+                key=f"join_type_{idx}",
+            )
+
+            relationship_type = st.selectbox(
+                "Relationship Type",
+                options=[
+                    "one_to_one",
+                    "many_to_one",
+                ],
+                index=relationship.relationship_type,
+                key=f"relationship_type_{idx}",
+            )
+
+            for col_idx, join_cols in enumerate(relationship.relationship_columns):
+                left_table_object = next(
+                    (
+                        table
+                        for table in st.session_state.semantic_model.tables
+                        if table.name == left_table
+                    )
+                )
+
+                right_table_object = next(
+                    (
+                        table
+                        for table in st.session_state.semantic_model.tables
+                        if table.name == right_table
+                    )
+                )
+                try:
+                    left_columns = []
+                    left_columns.extend(left_table_object.columns)
+                    left_columns.extend(left_table_object.dimensions)
+                    left_columns.extend(left_table_object.time_dimensions)
+                    left_columns.extend(left_table_object.measures)
+
+                    right_columns = []
+                    right_columns.extend(right_table_object.columns)
+                    right_columns.extend(right_table_object.dimensions)
+                    right_columns.extend(right_table_object.time_dimensions)
+                    right_columns.extend(right_table_object.measures)
+
+                    default_left_col = [col.name for col in left_columns].index(
+                        join_cols.left_column
+                    )
+                    default_right_col = [col.name for col in right_columns].index(
+                        join_cols.right_column
+                    )
+                except ValueError:
+                    default_left_col = 0
+                    default_right_col = 0
+                left_col = st.selectbox(
+                    "Left Column",
+                    options=[col.name for col in left_columns],
+                    index=default_left_col,
+                    key=f"left_col_{idx}_{col_idx}",
+                )
+                right_col = st.selectbox(
+                    "Right Column",
+                    options=[col.name for col in right_columns],
+                    index=default_right_col,
+                    key=f"right_col_{idx}_{col_idx}",
+                )
+
+            if st.button("Add join keys", key=f"add_join_keys_{idx}"):
+                relationship.relationship_columns.append(
+                    semantic_model_pb2.RelationKey(
+                        left_column="",
+                        right_column="",
+                    )
+                )
+
+    # If the user clicks "Add join", add a new join to the relationships list
+    if st.button("Add join"):
+        st.session_state.semantic_model.relationships.append(
+            semantic_model_pb2.Relationship(
+                left_table="",
+                right_table="",
+                join_type=semantic_model_pb2.JoinType.inner,
+                relationship_type=semantic_model_pb2.RelationshipType.one_to_one,
+                relationship_columns=[],
+            )
+        )
+
+    # If the user clicks "Save", save the relationships list to the session state
+    if st.button("Save"):
+        st.session_state.semantic_model.relationships = st.session_state.builder_joins
+        st.rerun()

--- a/admin_apps/journeys/joins.py
+++ b/admin_apps/journeys/joins.py
@@ -6,7 +6,6 @@ from streamlit_extras.row import row
 
 from semantic_model_generator.protos import semantic_model_pb2
 
-
 SUPPORTED_JOIN_TYPES = [
     join_type
     for join_type in semantic_model_pb2.JoinType.values()

--- a/admin_apps/journeys/joins.py
+++ b/admin_apps/journeys/joins.py
@@ -1,8 +1,149 @@
 import copy
+from typing import Optional
 
 import streamlit as st
 
 from semantic_model_generator.protos import semantic_model_pb2
+
+
+SUPPORTED_JOIN_TYPES = [
+    join_type
+    for join_type in semantic_model_pb2.JoinType.values()
+    if join_type != semantic_model_pb2.JoinType.join_type_unknown
+]
+SUPPORTED_RELATIONSHIP_TYPES = [
+    relationship_type
+    for relationship_type in semantic_model_pb2.RelationshipType.values()
+    if relationship_type
+    != semantic_model_pb2.RelationshipType.relationship_type_unknown
+]
+
+
+def relationship_builder(
+    relationship: semantic_model_pb2.Relationship, key: Optional[int] = 0
+) -> None:
+    """
+    Renders a UI for building/editing a semantic model relationship.
+    Args:
+        relationship: The relationship object to edit.
+        key: An optional key to use for the UI elements.
+
+    Returns:
+
+    """
+    with st.expander(f"Join {key}"):
+        relationship.name = st.text_input(
+            "Name", value=relationship.name, key=f"name_{key}"
+        )
+        # Logic to preselect the tables in the dropdown based on what's in the semantic model.
+        try:
+            default_left_table = [
+                table.name for table in st.session_state.semantic_model.tables
+            ].index(relationship.left_table)
+            default_right_table = [
+                table.name for table in st.session_state.semantic_model.tables
+            ].index(relationship.right_table)
+        except ValueError:
+            default_left_table = 0
+            default_right_table = 0
+        relationship.left_table = st.selectbox(
+            "Left Table",
+            options=[table.name for table in st.session_state.semantic_model.tables],
+            index=default_left_table,
+            key=f"left_table_{key}",
+        )
+
+        relationship.right_table = st.selectbox(
+            "Right Table",
+            options=[table.name for table in st.session_state.semantic_model.tables],
+            index=default_right_table,
+            key=f"right_table_{key}",
+        )
+
+        relationship.join_type = st.radio(  # type: ignore
+            "Join Type",
+            options=SUPPORTED_JOIN_TYPES,
+            format_func=lambda join_type: semantic_model_pb2.JoinType.Name(join_type),
+            index=SUPPORTED_JOIN_TYPES.index(relationship.join_type),
+        )
+
+        relationship.relationship_type = st.radio(  # type: ignore
+            "Relationship Type",
+            options=SUPPORTED_RELATIONSHIP_TYPES,
+            format_func=lambda relationship_type: semantic_model_pb2.RelationshipType.Name(
+                relationship_type
+            ),
+            index=SUPPORTED_RELATIONSHIP_TYPES.index(relationship.relationship_type),
+        )
+
+        # Builder section for the relationship's columns.
+        for col_idx, join_cols in enumerate(relationship.relationship_columns):
+            # Grabbing references to the exact Table objects that the relationship is pointing to.
+            # This allows us to pull the columns.
+            left_table_object = next(
+                (
+                    table
+                    for table in st.session_state.semantic_model.tables
+                    if table.name == relationship.left_table
+                )
+            )
+            right_table_object = next(
+                (
+                    table
+                    for table in st.session_state.semantic_model.tables
+                    if table.name == relationship.right_table
+                )
+            )
+
+            st.divider()
+            try:
+                left_columns = []
+                left_columns.extend(left_table_object.columns)
+                left_columns.extend(left_table_object.dimensions)
+                left_columns.extend(left_table_object.time_dimensions)
+                left_columns.extend(left_table_object.measures)
+
+                right_columns = []
+                right_columns.extend(right_table_object.columns)
+                right_columns.extend(right_table_object.dimensions)
+                right_columns.extend(right_table_object.time_dimensions)
+                right_columns.extend(right_table_object.measures)
+
+                default_left_col = [col.name for col in left_columns].index(
+                    join_cols.left_column
+                )
+                default_right_col = [col.name for col in right_columns].index(
+                    join_cols.right_column
+                )
+            except ValueError:
+                default_left_col = 0
+                default_right_col = 0
+
+            join_cols.left_column = st.selectbox(
+                "Left Column",
+                options=[col.name for col in left_columns],
+                index=default_left_col,
+                key=f"left_col_{key}_{col_idx}",
+            )
+            join_cols.right_column = st.selectbox(
+                "Right Column",
+                options=[col.name for col in right_columns],
+                index=default_right_col,
+                key=f"right_col_{key}_{col_idx}",
+            )
+
+            if st.button("Delete join key", key=f"delete_join_key_{key}_{col_idx}"):
+                relationship.relationship_columns.pop(col_idx)
+                st.rerun(scope="fragment")
+
+        if st.button("Add join keys", key=f"add_join_keys_{key}"):
+            relationship.relationship_columns.append(
+                semantic_model_pb2.RelationKey(
+                    left_column="",
+                    right_column="",
+                )
+            )
+            st.rerun(scope="fragment")
 
 
 @st.dialog("Join Builder", width="large")
@@ -14,136 +155,8 @@ def joins_dialog() -> None:
             :
         ]
 
-    # For each relationship, render a relationship builder
     for idx, relationship in enumerate(st.session_state.builder_joins):
-        with st.expander(f"Join {idx}"):
-            name = st.text_input("Name", value=relationship.name, key=f"name_{idx}")
-            relationship.name = name
-            # Logic to preselect the tables in the dropdown based on what's in the semantic model.
-            try:
-                default_left_table = [
-                    table.name for table in st.session_state.semantic_model.tables
-                ].index(relationship.left_table)
-                default_right_table = [
-                    table.name for table in st.session_state.semantic_model.tables
-                ].index(relationship.right_table)
-            except ValueError:
-                default_left_table = 0
-                default_right_table = 0
-            left_table = st.selectbox(
-                "Left Table",
-                options=[
-                    table.name for table in st.session_state.semantic_model.tables
-                ],
-                index=default_left_table,
-                key=f"left_table_{idx}",
-            )
-            relationship.left_table = left_table
-
-            right_table = st.selectbox(
-                "Right Table",
-                options=[
-                    table.name for table in st.session_state.semantic_model.tables
-                ],
-                index=default_right_table,
-                key=f"right_table_{idx}",
-            )
-            relationship.right_table = right_table
-
-            join_type = st.selectbox(
-                "Join Type",
-                options=["inner", "left_outer"],
-                index=["inner", "left_outer"].index(
-                    semantic_model_pb2.JoinType.Name(relationship.join_type)
-                ),
-                key=f"join_type_{idx}",
-            )
-            relationship.join_type = join_type
-
-            relationship_type = st.selectbox(
-                "Relationship Type",
-                options=[
-                    "one_to_one",
-                    "many_to_one",
-                ],
-                index=["one_to_one", "many_to_one"].index(
-                    semantic_model_pb2.RelationshipType.Name(
-                        relationship.relationship_type
-                    ),
-                ),
-                key=f"relationship_type_{idx}",
-            )
-            relationship.relationship_type = relationship_type
-
-            for col_idx, join_cols in enumerate(relationship.relationship_columns):
-                # Grabbing references to the exact Table objects that the relationship is pointing to.
-                # This allows us to pull the columns.
-                left_table_object = next(
-                    (
-                        table
-                        for table in st.session_state.semantic_model.tables
-                        if table.name == left_table
-                    )
-                )
-                right_table_object = next(
-                    (
-                        table
-                        for table in st.session_state.semantic_model.tables
-                        if table.name == right_table
-                    )
-                )
-
-                st.divider()
-                try:
-                    left_columns = []
-                    left_columns.extend(left_table_object.columns)
-                    left_columns.extend(left_table_object.dimensions)
-                    left_columns.extend(left_table_object.time_dimensions)
-                    left_columns.extend(left_table_object.measures)
-
-                    right_columns = []
-                    right_columns.extend(right_table_object.columns)
-                    right_columns.extend(right_table_object.dimensions)
-                    right_columns.extend(right_table_object.time_dimensions)
-                    right_columns.extend(right_table_object.measures)
-
-                    default_left_col = [col.name for col in left_columns].index(
-                        join_cols.left_column
-                    )
-                    default_right_col = [col.name for col in right_columns].index(
-                        join_cols.right_column
-                    )
-                except ValueError:
-                    default_left_col = 0
-                    default_right_col = 0
-
-                left_col = st.selectbox(
-                    "Left Column",
-                    options=[col.name for col in left_columns],
-                    index=default_left_col,
-                    key=f"left_col_{idx}_{col_idx}",
-                )
-                join_cols.left_column = left_col
-                right_col = st.selectbox(
-                    "Right Column",
-                    options=[col.name for col in right_columns],
-                    index=default_right_col,
-                    key=f"right_col_{idx}_{col_idx}",
-                )
-                join_cols.right_column = right_col
-
-                if st.button("Delete join key", key=f"delete_join_key_{idx}_{col_idx}"):
-                    relationship.relationship_columns.pop(col_idx)
-                    st.rerun(scope="fragment")
-
-            if st.button("Add join keys", key=f"add_join_keys_{idx}"):
-                relationship.relationship_columns.append(
-                    semantic_model_pb2.RelationKey(
-                        left_column="",
-                        right_column="",
-                    )
-                )
-                st.rerun(scope="fragment")
+        relationship_builder(relationship, idx)
 
     # If the user clicks "Add join", add a new join to the relationships list
     if st.button("Add join"):

--- a/admin_apps/journeys/joins.py
+++ b/admin_apps/journeys/joins.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Optional
 
 import streamlit as st

--- a/admin_apps/partner/looker.py
+++ b/admin_apps/partner/looker.py
@@ -226,7 +226,14 @@ def set_looker_semantic() -> None:
     with col2:
         sample_values = input_sample_value_num()
 
+    experimental_features = st.checkbox(
+        "Enable experimental features (optional)",
+        help="Checking this box will enable generation of experimental features in the semantic model. If enabling this setting, please ensure that you have the proper parameters set on your Snowflake account. Some features (e.g. joins) are currently in Private Preview and available only to select accounts. Reach out to your account team for access.",
+    )
+
     if st.button("Continue", type="primary"):
+        st.session_state["experimental_features"] = experimental_features
+
         if check_valid_session_state_values(
             [
                 "looker_model_name",
@@ -265,6 +272,7 @@ def set_looker_semantic() -> None:
                     model_name,
                     sample_values,
                     [full_tablename],
+                    allow_joins=experimental_features,
                 )
                 st.session_state["partner_setup"] = True
 


### PR DESCRIPTION
This PR implements a UI within the edit flow for specifying join paths. It is only shown if the user has experimental features enabled.

The UI is used to add and edit join paths between two tables, specifying the join/relationship type as well as the join keys. Upon submitting, the joins are serialized into the YAML.


https://github.com/user-attachments/assets/dcec33fe-8afd-4328-9ff4-5ef72e97723f



