### PR TITLE
Add debug options for chatting

### DIFF
--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -6,7 +6,6 @@ import pandas as pd
 import requests
 import sqlglot
 import streamlit as st
-from requests import request
 from snowflake.connector import ProgrammingError, SnowflakeConnection
 from streamlit.delta_generator import DeltaGenerator
 from streamlit_extras.row import row

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -296,7 +296,7 @@ def display_content(
                 ):
                     edit_verified_query(conn, sql, question, message_index)
 
-    if request_id:
+    if request_id and st.session_state.chat_debug:
         st.caption(f"Request ID: {request_id}")
 
 
@@ -674,6 +674,25 @@ def set_up_requirements() -> None:
         st.rerun()
 
 
+@st.dialog("Chat Settings", width="small")
+def chat_settings_dialog() -> None:
+    """
+    Dialog that allows user to toggle on/off certain settings about the chat experience.
+    """
+
+    debug = st.toggle(
+        "Debug mode",
+        value=st.session_state.chat_debug,
+        help="Enable debug mode to see additional information (e.g. request ID).",
+    )
+
+    # TODO: This is where multiturn toggle will go.
+
+    if st.button("Save"):
+        st.session_state.chat_debug = debug
+        st.rerun()
+
+
 VALIDATE_HELP = """Save and validate changes to the active semantic model in this app. This is
 useful so you can then play with it in the chat panel on the right side."""
 
@@ -724,6 +743,9 @@ def show() -> None:
             yaml_editor(editor_contents)
 
         with chat_container:
-            st.markdown("**Chat**")
+            header_row = row([0.85, 0.15], vertical_align="center")
+            header_row.markdown("**Chat**")
+            if header_row.button("Settings"):
+                chat_settings_dialog()
             # We still initialize an empty connector and pass it down in order to propagate the connector auth token.
             chat_and_edit_vqr(get_snowflake_connection())

--- a/admin_apps/journeys/iteration.py
+++ b/admin_apps/journeys/iteration.py
@@ -119,6 +119,7 @@ def process_message(_conn: SnowflakeConnection, prompt: str) -> None:
         with st.spinner("Generating response..."):
             response = send_message(_conn=_conn, prompt=prompt)
             content = response["message"]["content"]
+            # Grab the request ID from the response and stash it in the chat message object.
             request_id = response["request_id"]
             display_content(conn=_conn, content=content, request_id=request_id)
     st.session_state.messages.append(
@@ -295,6 +296,8 @@ def display_content(
                 ):
                     edit_verified_query(conn, sql, question, message_index)
 
+    # If debug mode is enabled, we render the request ID. Note that request IDs are currently only plumbed
+    # through for assistant messages, as we obtain the request ID as part of the Analyst response.
     if request_id and st.session_state.chat_debug:
         st.caption(f"Request ID: {request_id}")
 
@@ -334,7 +337,9 @@ def chat_and_edit_vqr(_conn: SnowflakeConnection) -> None:
                     conn=_conn,
                     content=message["content"],
                     message_index=message_index,
-                    request_id=message.get("request_id"),
+                    request_id=message.get(
+                        "request_id"
+                    ),  # Safe get since user messages have no request IDs
                 )
 
     chat_placeholder = (

--- a/admin_apps/shared_utils.py
+++ b/admin_apps/shared_utils.py
@@ -169,6 +169,10 @@ def init_session_states() -> None:
     if "last_validated_model" not in st.session_state:
         st.session_state.last_validated_model = semantic_model_pb2.SemanticModel()
 
+    # Chat display settings.
+    if "chat_debug" not in st.session_state:
+        st.session_state.chat_debug = False
+
     # initialize session states for the chat page.
     if "messages" not in st.session_state:
         # messages store all chat histories


### PR DESCRIPTION
For users trying to debug failures, it is often helpful to provide a request ID. Request IDs are not currently shown anywhere in the app. This PR adds a debug mode setting to the chat window that, when enabled, showcases request IDs for all assistant messages. This will make it easier to provide the relevant info to engineers.



https://github.com/user-attachments/assets/e7c00459-35cc-4039-a386-a2d796c1ac9a

