### PR TITLE
Optional multiturn support

### DIFF
--- a/admin_apps/shared_utils.py
+++ b/admin_apps/shared_utils.py
@@ -172,6 +172,8 @@ def init_session_states() -> None:
     # Chat display settings.
     if "chat_debug" not in st.session_state:
         st.session_state.chat_debug = False
+    if "multiturn" not in st.session_state:
+        st.session_state.multiturn = False
 
     # initialize session states for the chat page.
     if "messages" not in st.session_state:


### PR DESCRIPTION
This PR establishes multiturn support for users that have this flag enabled. Similar to joins, since we cannot read Snowflake parameters from this app, we need to rely on the user manually giving the go-ahead. For multiturn, this is done in the "chat settings" panel. 

In the recording below, note that when multiturn is enabled, Analyst can contextualize questions in the context of previous responses.


https://github.com/user-attachments/assets/a63f38e3-ca1d-4518-a46f-be57c669e1de




