### PR TITLE
Fix encoding before upload to stage

### DIFF
--- a/app_utils/shared_utils.py
+++ b/app_utils/shared_utils.py
@@ -994,7 +994,7 @@ def upload_yaml(file_name: str) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         tmp_file_path = os.path.join(temp_dir, f"{file_name}.yaml")
 
-        with open(tmp_file_path, "w") as temp_file:
+        with open(tmp_file_path, "w", encoding='utf-8') as temp_file:
             temp_file.write(yaml)
 
         st.session_state.session.file.put(


### PR DESCRIPTION
Add utf-8 encoding when writing file before stage upload to mitigate decode error received. Reproducing this error without fix can be done by adding a sample value with an accent, e.g. `RAMÍREZ`.