### PR TITLE
Pop user message from multiturn if error is encountered

### DIFF
--- a/journeys/iteration.py
+++ b/journeys/iteration.py
@@ -91,6 +91,9 @@ def process_message(_conn: SnowflakeConnection, prompt: str) -> None:
                 )
             except ValueError as e:
                 st.error(e)
+                # Remove the user message from the chat history if the request fails.
+                # We should only save messages to history for successful (user, assistant) turns.
+                st.session_state.messages.pop()
 
 
 def show_expr_for_ref(message_index: int) -> None:


### PR DESCRIPTION
If a user has multiturn enabled but encounters an error, they are permanently stuck in a state where there are 2+ consecutive user messages in the conversation which prevents them from using the app at all unless they reload the page.

One option to fix this is to only save messages if the content can be successfully parsed. As such, if an error is encountered and we couldn't parse the assistant message, we remove the user message from the Streamlit session state.

Here is an example of the behavior, locally I've forced the API call to intermittently return an error. Note that we run into an error but are able to send later messages successfully, preserving multiturn context:




https://github.com/user-attachments/assets/07d37267-0205-4812-aed9-5c86a8f8afcb




Single-turn example:


https://github.com/user-attachments/assets/b1baa51d-9276-4a33-9008-11137d542329



