### PR TITLE
Parallelize table generation

### DIFF
--- a/semantic_model_generator/generate_model.py
+++ b/semantic_model_generator/generate_model.py
@@ -207,11 +207,12 @@ def raw_schema_to_semantic_context(
     # This is done concurrently because `process_table` is I/O bound, executing potentially long-running
     # queries to fetch column metadata and sample values.
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        future_to_table = [
+        table_futures = [
             executor.submit(process_table, table, conn, n_sample_values)
             for table in base_tables
         ]
-        for future in concurrent.futures.as_completed(future_to_table):
+        concurrent.futures.wait(table_futures)
+        for future in table_futures:
             table_object = future.result()
             table_objects.append(table_object)
 

--- a/semantic_model_generator/generate_model.py
+++ b/semantic_model_generator/generate_model.py
@@ -1,4 +1,6 @@
+import concurrent.futures
 import os
+import time
 from datetime import datetime
 from typing import List, Optional
 
@@ -160,6 +162,37 @@ def _raw_table_to_semantic_context_table(
     )
 
 
+def process_table(
+    table: str, conn: SnowflakeConnection, n_sample_values: int
+) -> semantic_model_pb2.Table:
+    fqn_table = create_fqn_table(table)
+    valid_schemas_tables_columns_df = get_valid_schemas_tables_columns_df(
+        conn=conn,
+        db_name=fqn_table.database,
+        table_schema=fqn_table.schema_name,
+        table_names=[fqn_table.table],
+    )
+    assert not valid_schemas_tables_columns_df.empty
+
+    valid_columns_df_this_table = valid_schemas_tables_columns_df[
+        valid_schemas_tables_columns_df["TABLE_NAME"] == fqn_table.table
+    ]
+
+    raw_table = get_table_representation(
+        conn=conn,
+        schema_name=fqn_table.database + "." + fqn_table.schema_name,
+        table_name=fqn_table.table,
+        table_index=0,
+        ndv_per_column=n_sample_values,
+        columns_df=valid_columns_df_this_table,
+    )
+    return _raw_table_to_semantic_context_table(
+        database=fqn_table.database,
+        schema=fqn_table.schema_name,
+        raw_table=raw_table,
+    )
+
+
 def raw_schema_to_semantic_context(
     base_tables: List[str],
     semantic_model_name: str,
@@ -167,69 +200,21 @@ def raw_schema_to_semantic_context(
     n_sample_values: int = _DEFAULT_N_SAMPLE_VALUES_PER_COL,
     allow_joins: Optional[bool] = False,
 ) -> semantic_model_pb2.SemanticModel:
-    """
-    Converts a list of fully qualified Snowflake table names into a semantic model.
-
-    Parameters:
-    - base_tables  (list[str]): Fully qualified table names to include in the semantic model.
-    - snowflake_account (str): Snowflake account identifier.
-    - semantic_model_name (str): A meaningful semantic model name.
-    - conn (SnowflakeConnection): SnowflakeConnection to reuse.
-    - n_sample_values (int): The number of sample values per col.
-
-    Returns:
-    - The semantic model (semantic_model_pb2.SemanticModel).
-
-    This function fetches metadata for the specified tables, performs schema validation, extracts key information,
-    enriches metadata from the Snowflake database, and constructs a semantic model in protobuf format.
-    It handles different databases and schemas within the same account by creating unique Snowflake connections as needed.
-
-    Raises:
-    - AssertionError: If no valid tables are found in the specified schema.
-    """
-
-    # For FQN tables, create a new snowflake connection per table in case the db/schema is different.
+    start_time = time.time()
     table_objects = []
-    unique_database_schema: List[str] = []
-    for table in base_tables:
-        # Verify this is a valid FQN table. For now, we check that the table follows the following format.
-        # {database}.{schema}.{table}
-        fqn_table = create_fqn_table(table)
-        fqn_databse_schema = f"{fqn_table.database}.{fqn_table.schema_name}"
 
-        if fqn_databse_schema not in unique_database_schema:
-            unique_database_schema.append(fqn_databse_schema)
-
-        logger.info(f"Pulling column information from {fqn_table}")
-        valid_schemas_tables_columns_df = get_valid_schemas_tables_columns_df(
-            conn=conn,
-            db_name=fqn_table.database,
-            table_schema=fqn_table.schema_name,
-            table_names=[fqn_table.table],
-        )
-        assert not valid_schemas_tables_columns_df.empty
-
-        # get the valid columns for this table.
-        valid_columns_df_this_table = valid_schemas_tables_columns_df[
-            valid_schemas_tables_columns_df["TABLE_NAME"] == fqn_table.table
-        ]
-
-        raw_table = get_table_representation(
-            conn=conn,
-            schema_name=fqn_databse_schema,  # Fully-qualified schema
-            table_name=fqn_table.table,  # Non-qualified table name
-            table_index=0,
-            ndv_per_column=n_sample_values,  # number of sample values to pull per column.
-            columns_df=valid_columns_df_this_table,
-            max_workers=1,
-        )
-        table_object = _raw_table_to_semantic_context_table(
-            database=fqn_table.database,
-            schema=fqn_table.schema_name,
-            raw_table=raw_table,
-        )
-        table_objects.append(table_object)
-    # TODO(jhilgart): Call cortex model to generate a semantically friendly name here.
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_to_table = {
+            executor.submit(process_table, table, conn, n_sample_values): table
+            for table in base_tables
+        }
+        for future in concurrent.futures.as_completed(future_to_table):
+            table = future_to_table[future]
+            try:
+                table_object = future.result()
+                table_objects.append(table_object)
+            except Exception as exc:
+                logger.error(f"Table {table} generated an exception: {exc}")
 
     placeholder_relationships = _get_placeholder_joins() if allow_joins else None
     context = semantic_model_pb2.SemanticModel(
@@ -237,6 +222,9 @@ def raw_schema_to_semantic_context(
         tables=table_objects,
         relationships=placeholder_relationships,
     )
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+    logger.info(f"Time taken to generate semantic model: {elapsed_time} seconds.")
     return context
 
 

--- a/semantic_model_generator/generate_model.py
+++ b/semantic_model_generator/generate_model.py
@@ -206,7 +206,7 @@ def raw_schema_to_semantic_context(
     # Create a Table object representation for each provided table name.
     # This is done concurrently because `process_table` is I/O bound, executing potentially long-running
     # queries to fetch column metadata and sample values.
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         table_futures = [
             executor.submit(process_table, table, conn, n_sample_values)
             for table in base_tables

--- a/semantic_model_generator/snowflake_utils/snowflake_connector.py
+++ b/semantic_model_generator/snowflake_utils/snowflake_connector.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import json
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, List, Optional, TypeVar
@@ -195,9 +196,15 @@ def _get_column_representation(
         try:
             cursor = conn.cursor(DictCursor)
             assert cursor is not None, "Cursor is unexpectedly None"
-            cursor_execute = cursor.execute(
-                f'select distinct "{column_name}" from {schema_name}.{table_name} limit {ndv}'
-            )
+            query = f"""
+                SELECT ARRAY_SLICE(ARRAY_UNIQUE_AGG("{column_name}"), 0, {ndv}) AS unique_values
+                FROM (
+                    SELECT "{column_name}"
+                    FROM {schema_name}.{table_name}
+                    SAMPLE (1000 ROWS)
+                )
+            """
+            cursor_execute = cursor.execute(query)
             assert cursor_execute is not None, "cursor_execute should not be none "
             res = cursor_execute.fetchall()
             # Cast all values to string to ensure the list is json serializable.
@@ -205,9 +212,9 @@ def _get_column_representation(
             # json serializable (e.g. datetime objects) and apply the appropriate casting
             # in just those cases.
             if len(res) > 0:
-                if isinstance(res[0], dict):
-                    col_key = [k for k in res[0].keys()][0]
-                    column_values = [str(r[col_key]) for r in res]
+                if res and isinstance(res[0], dict) and "UNIQUE_VALUES" in res[0]:
+                    unique_values_list = json.loads(res[0]["UNIQUE_VALUES"])
+                    column_values = [str(value) for value in unique_values_list]
                 else:
                     raise ValueError(
                         f"Expected the first item of res to be a dict. Instead passed {res}"

--- a/semantic_model_generator/snowflake_utils/snowflake_connector.py
+++ b/semantic_model_generator/snowflake_utils/snowflake_connector.py
@@ -146,7 +146,6 @@ def get_table_representation(
     table_index: int,
     ndv_per_column: int,
     columns_df: pd.DataFrame,
-    max_workers: int,
 ) -> Table:
     table_comment = _get_table_comment(conn, schema_name, table_name, columns_df)
 
@@ -160,7 +159,7 @@ def get_table_representation(
             ndv=ndv_per_column,
         )
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+    with concurrent.futures.ThreadPoolExecutor() as executor:
         future_to_col_index = {
             executor.submit(_get_col, col_index, column_row): col_index
             for col_index, (_, column_row) in enumerate(columns_df.iterrows())

--- a/semantic_model_generator/snowflake_utils/snowflake_connector.py
+++ b/semantic_model_generator/snowflake_utils/snowflake_connector.py
@@ -159,7 +159,7 @@ def get_table_representation(
             ndv=ndv_per_column,
         )
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
         future_to_col_index = {
             executor.submit(_get_col, col_index, column_row): col_index
             for col_index, (_, column_row) in enumerate(columns_df.iterrows())


### PR DESCRIPTION
**Investigating getting this working in SiS**


When generating a semantic model, we currently iterate through all of the tables that the user has specified and generate a representation for each. This is done sequentially, which leads to long latencies. This PR parallelizes the table generation which drastically reduces generation time.

For example, here are the generation times for a large semantic model containing 20 tables from `COVID19_EPIDEMIOLOGICAL_DATA`.

Sequential processing:
```
2024-10-30 13:54:26.497 | INFO - Time to generate semantic model: 187.59221196174622 seconds.
```

Concurrent processing:
```
2024-10-30 13:49:39.478 | INFO - Time taken to generate semantic model: 29.945907831192017 seconds.
```
