### PR TITLE
Fix typing import that causes runtime error

### DIFF
--- a/partner/partner_utils.py
+++ b/partner/partner_utils.py
@@ -1,7 +1,7 @@
 import json
 import time
 from enum import Enum
-from typing import Any
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
```
2024-10-30 15:04:13.281 Uncaught app exception
Traceback (most recent call last):
  File "/opt/homebrew/anaconda3/envs/semantic_model/lib/python3.11/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 589, in _run_script
    exec(code, module.__dict__)
  File "/Users/caxu/semantic-model-generator/app.py", line 119, in <module>
    onboarding_dialog()
  File "/Users/caxu/semantic-model-generator/app.py", line 100, in onboarding_dialog
    partner.show()
  File "/Users/caxu/semantic-model-generator/journeys/partner.py", line 24, in show
    partner_semantic_setup()
  File "/opt/homebrew/anaconda3/envs/semantic_model/lib/python3.11/site-packages/streamlit/elements/dialog_decorator.py", line 77, in wrap
    fragmented_dialog_content()
  File "/opt/homebrew/anaconda3/envs/semantic_model/lib/python3.11/site-packages/streamlit/runtime/fragment.py", line 194, in wrap
    return wrapped_fragment()
           ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/semantic_model/lib/python3.11/site-packages/streamlit/runtime/fragment.py", line 180, in wrapped_fragment
    result = non_optional_func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/anaconda3/envs/semantic_model/lib/python3.11/site-packages/streamlit/elements/dialog_decorator.py", line 71, in dialog_content
    _ = non_optional_func(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/caxu/semantic-model-generator/journeys/partner.py", line 9, in partner_semantic_setup
    from partner.partner_utils import configure_partner_semantic
  File "/Users/caxu/semantic-model-generator/partner/partner_utils.py", line 97, in <module>
    class PartnerCompareRow:
  File "/Users/caxu/semantic-model-generator/partner/partner_utils.py", line 116, in PartnerCompareRow
    def render_row(self) -> Union[None, dict[str, Any]]:  # type: ignore
                            ^^^^^
NameError: name 'Union' is not defined
```