### PR TITLE
feat: upgrade st.experimental_dialog

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ from semantic_model_generator.snowflake_utils.env_vars import (  # noqa: E402
 )
 
 
-@st.experimental_dialog(title="Connection Error")
+@st.dialog(title="Connection Error")
 def failed_connection_popup() -> None:
     """
     Renders a dialog box detailing that the credentials provided could not be used to connect to Snowflake.

--- a/app_utils/shared_utils.py
+++ b/app_utils/shared_utils.py
@@ -72,7 +72,7 @@ def set_streamlit_location() -> bool:
     return sis
 
 
-@st.experimental_dialog(title="Setup")
+@st.dialog(title="Setup")
 def env_setup_popup(missing_env_vars: list[str]) -> None:
     """
     Renders a dialog box to prompt the user to set the required connection setup.
@@ -388,7 +388,7 @@ def init_session_states() -> None:
         st.session_state.confirmed_edits = False
 
 
-@st.experimental_dialog("Edit Dimension")  # type: ignore[misc]
+@st.dialog("Edit Dimension")  # type: ignore[misc]
 def edit_dimension(table_name: str, dim: semantic_model_pb2.Dimension) -> None:
     """
     Renders a dialog box to edit an existing dimension.
@@ -438,7 +438,7 @@ def edit_dimension(table_name: str, dim: semantic_model_pb2.Dimension) -> None:
         st.rerun()
 
 
-@st.experimental_dialog("Add Dimension")  # type: ignore[misc]
+@st.dialog("Add Dimension")  # type: ignore[misc]
 def add_dimension(table: semantic_model_pb2.Table) -> None:
     """
     Renders a dialog box to add a new dimension.
@@ -477,7 +477,7 @@ def add_dimension(table: semantic_model_pb2.Table) -> None:
         st.rerun()
 
 
-@st.experimental_dialog("Edit Measure")  # type: ignore[misc]
+@st.dialog("Edit Measure")  # type: ignore[misc]
 def edit_measure(table_name: str, measure: semantic_model_pb2.Measure) -> None:
     """
     Renders a dialog box to edit an existing measure.
@@ -550,7 +550,7 @@ def edit_measure(table_name: str, measure: semantic_model_pb2.Measure) -> None:
         st.rerun()
 
 
-@st.experimental_dialog("Add Measure")  # type: ignore[misc]
+@st.dialog("Add Measure")  # type: ignore[misc]
 def add_measure(table: semantic_model_pb2.Table) -> None:
     """
     Renders a dialog box to add a new measure.
@@ -610,7 +610,7 @@ def add_measure(table: semantic_model_pb2.Table) -> None:
         st.rerun()
 
 
-@st.experimental_dialog("Edit Time Dimension")  # type: ignore[misc]
+@st.dialog("Edit Time Dimension")  # type: ignore[misc]
 def edit_time_dimension(
     table_name: str, tdim: semantic_model_pb2.TimeDimension
 ) -> None:
@@ -655,7 +655,7 @@ def edit_time_dimension(
         st.rerun()
 
 
-@st.experimental_dialog("Add Time Dimension")  # type: ignore[misc]
+@st.dialog("Add Time Dimension")  # type: ignore[misc]
 def add_time_dimension(table: semantic_model_pb2.Table) -> None:
     """
     Renders a dialog box to add a new time dimension.
@@ -853,7 +853,7 @@ def display_table(table_name: str) -> None:
         add_time_dimension(table)
 
 
-@st.experimental_dialog("Add Table")  # type: ignore[misc]
+@st.dialog("Add Table")  # type: ignore[misc]
 def add_new_table() -> None:
     """
     Renders a dialog box to add a new logical table.
@@ -970,7 +970,7 @@ def import_yaml() -> None:
             st.rerun()
 
 
-@st.experimental_dialog("Model YAML", width="large")  # type: ignore
+@st.dialog("Model YAML", width="large")  # type: ignore
 def show_yaml_in_dialog() -> None:
     yaml = proto_to_yaml(st.session_state.semantic_model)
     st.code(

--- a/journeys/builder.py
+++ b/journeys/builder.py
@@ -68,7 +68,7 @@ def update_tables() -> None:
     st.session_state["selected_tables"] = valid_selected_tables
 
 
-@st.experimental_dialog("Selecting your tables", width="large")
+@st.dialog("Selecting your tables", width="large")
 def table_selector_dialog() -> None:
     st.write(
         "Please fill out the following fields to start building your semantic model."

--- a/journeys/iteration.py
+++ b/journeys/iteration.py
@@ -118,7 +118,7 @@ def show_expr_for_ref(message_index: int) -> None:
         st.table(col_df.set_index(col_df.columns[1]))
 
 
-@st.experimental_dialog("Edit", width="large")
+@st.dialog("Edit", width="large")
 def edit_verified_query(
     conn: SnowflakeConnection, sql: str, question: str, message_index: int
 ) -> None:
@@ -370,7 +370,7 @@ def chat_and_edit_vqr(_conn: SnowflakeConnection) -> None:
         st.session_state.active_suggestion = None
 
 
-@st.experimental_dialog("Upload", width="small")
+@st.dialog("Upload", width="small")
 def upload_dialog(content: str) -> None:
     def upload_handler(file_name: str) -> None:
         if not st.session_state.validated and changed_from_last_validated_model():
@@ -456,7 +456,7 @@ def update_container(
     container.markdown(content)
 
 
-@st.experimental_dialog("Error", width="small")
+@st.dialog("Error", width="small")
 def exception_as_dialog(e: Exception) -> None:
     st.error(f"An error occurred: {e}")
 
@@ -578,7 +578,7 @@ def yaml_editor(yaml_str: str) -> None:
         update_container(status_container, "editing", prefix=status_container_title)
 
 
-@st.experimental_dialog("Welcome to the Iteration app! 💬", width="large")
+@st.dialog("Welcome to the Iteration app! 💬", width="large")
 def set_up_requirements() -> None:
     """
     Collects existing YAML location from the user so that we can download it.
@@ -629,7 +629,7 @@ def set_up_requirements() -> None:
         st.rerun()
 
 
-@st.experimental_dialog("Chat Settings", width="small")
+@st.dialog("Chat Settings", width="small")
 def chat_settings_dialog() -> None:
     """
     Dialog that allows user to toggle on/off certain settings about the chat experience.

--- a/journeys/joins.py
+++ b/journeys/joins.py
@@ -172,7 +172,7 @@ def relationship_builder(
             st.rerun()
 
 
-@st.experimental_dialog("Join Builder", width="large")
+@st.dialog("Join Builder", width="large")
 def joins_dialog() -> None:
     if "builder_joins" not in st.session_state:
         # Making a copy of the original relationships list so we can modify freely without affecting the original.

--- a/journeys/partner.py
+++ b/journeys/partner.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
 
-@st.experimental_dialog("Partner Semantic Support", width="large")
+@st.dialog("Partner Semantic Support", width="large")
 def partner_semantic_setup() -> None:
     """
     Renders the partner semantic setup dialog with instructions.

--- a/partner/partner_utils.py
+++ b/partner/partner_utils.py
@@ -236,7 +236,7 @@ def compare_data_types(
         return "TEXT"
 
 
-@st.experimental_dialog("Integrate partner tool semantic specs", width="large")
+@st.dialog("Integrate partner tool semantic specs", width="large")
 def integrate_partner_semantics() -> None:
     """
     Runs UI module for comparing Cortex and Partner fields for integration.


### PR DESCRIPTION
`st.experimental_dialog` should no longer be experimental. This upgrades all 19 instances of its usage
with [`st.dialog`](https://docs.streamlit.io/develop/api-reference/execution-flow/st.dialog).

