### PR TITLE
Fixed Download Button Help Constant

### DIFF
--- a/journeys/iteration.py
+++ b/journeys/iteration.py
@@ -525,7 +525,7 @@ def yaml_editor(yaml_str: str) -> None:
             file_name="semantic_model.yaml",
             mime="text/yaml",
             use_container_width=True,
-            help=UPLOAD_HELP,
+            help=DOWNLOAD_HELP,
         )
 
     if button_row.button(


### PR DESCRIPTION
The help constant for the download button was set to UPLOAD_HELP instead of DOWNLOAD_HELP.  This was causing the hover help on the button to show incorrectly. 